### PR TITLE
chore: Update the default value of ZSH_BASH_COMPLETIONS_FALLBACK_PATH

### DIFF
--- a/zsh-bash-completions-fallback.plugin.zsh
+++ b/zsh-bash-completions-fallback.plugin.zsh
@@ -63,7 +63,7 @@ function _bash_completions_fetch_supported_commands {
     setopt extended_glob typeset_silent no_short_loops
     unsetopt nomatch
 
-    local bash_completions=${ZSH_BASH_COMPLETIONS_FALLBACK_PATH:-/usr/share/bash-completion}
+    local bash_completions=${ZSH_BASH_COMPLETIONS_FALLBACK_PATH:-${${(@s/:/)${XDG_DATA_DIRS:-/usr/share}}[1]}/bash-completion}
     local -a dirs=(
         ${BASH_COMPLETION_USER_DIR:-${XDG_DATA_HOME:-$HOME/.local/share}/bash-completion}/completions
     )
@@ -91,7 +91,7 @@ function _bash_completions_fetch_supported_commands {
 }
 
 function _bash_completions_load {
-    local bash_completions=${ZSH_BASH_COMPLETIONS_FALLBACK_PATH:-/usr/share/bash-completion}
+    local bash_completions=${ZSH_BASH_COMPLETIONS_FALLBACK_PATH:-${${(@s/:/)${XDG_DATA_DIRS:-/usr/share}}[1]}/bash-completion}
     local reserved_words=(
         "do"
         "done"


### PR DESCRIPTION
In some OSs, we have different `/usr/share`:

- Android [termux](https://termux.dev/): `/data/data/com.termux/files/usr/share`
- NixOS: `/run/current-system/sw/share`

Use `$XDG_DATA_DIRS` to set the default value of `$ZSH_BASH_COMPLETIONS_FALLBACK_PATH`
can save user's troublesome to set a new variable `$ZSH_BASH_COMPLETIONS_FALLBACK_PATH`.